### PR TITLE
Use the page object design pattern for UI tests

### DIFF
--- a/ui_tests/features/environment.py
+++ b/ui_tests/features/environment.py
@@ -31,6 +31,8 @@ def before_scenario(context, scenario):
       context.browser = webdriver.Remote(
       command_executor="http://localhost:4444/wd/hub",
       desired_capabilities=capabilities)
+
+      context.browser.implicitly_wait(10)
   
      
 

--- a/ui_tests/features/steps/helpers/base_page.py
+++ b/ui_tests/features/steps/helpers/base_page.py
@@ -1,0 +1,74 @@
+class BasePage(object):
+    """
+    Base page object.
+    """
+
+    def __init__(self, context):
+        self.browser = context.browser
+
+    def visit(self, url: str):
+        """
+        Go to the provided url and maximize the window.
+
+        Arguments
+        ---------
+        url: str
+            URL to go to.
+        """
+
+        self.browser.get(url)
+        self.browser.maximize_window()
+
+    def find_element(self, loc: tuple):
+        """
+        Find the provided element in the browser.
+
+        Arguments
+        ---------
+        loc: tuple
+            Locator and the attribute value, e.g. loc = (By.ID, "username")
+        """
+
+        return self.browser.find_element(*loc)
+
+    def input(self, el, text: str):
+        """
+        Inputs text into the provided element.
+
+        Arguments
+        ---------
+        el: any
+            Element to enter the text into.
+        text: str
+            Text to enter.
+        """
+
+        el.click()
+        el.clear()
+        el.send_keys(text)
+
+    def __getattr__(self, attr: str):
+        """
+        Searches the `locators` dictionary defined in the class
+        and returns an element based on the record found in the dictionary.
+
+        Arguments
+        ---------
+        attr: str
+            Name of the attribute to find an element for.
+
+        Usage
+        -----
+        class LoginPage(BasePage):
+            locators = {
+                "confirm_btn": (By.ID, "kc-login"),
+            }
+
+        login_page = LoginPage(context)\\
+        login_page.confirm_btn.click()
+        """
+
+        if self.locators and attr in self.locators:
+            return self.find_element(self.locators[attr])
+        else:
+            raise AttributeError(attr)

--- a/ui_tests/features/steps/helpers/login_page.py
+++ b/ui_tests/features/steps/helpers/login_page.py
@@ -1,0 +1,14 @@
+from helpers.base_page import BasePage
+from selenium.webdriver.common.by import By
+
+class LoginPage(BasePage):
+    """
+    Page class for the RHub login page.
+    """
+
+    locators = {
+        "login_btn": (By.XPATH, "/html/body/div/div/main/div/div[1]/div[2]/button"),
+        "sign_in_btn": (By.ID, "kc-login"),
+        "username": (By.ID, "username"),
+        "password": (By.ID, "password")
+    }

--- a/ui_tests/features/steps/helpers/main_page.py
+++ b/ui_tests/features/steps/helpers/main_page.py
@@ -1,0 +1,11 @@
+from helpers.base_page import BasePage
+from selenium.webdriver.common.by import By
+
+class MainPage(BasePage):
+    """
+    Page class for the RHub main page.
+    """
+
+    locators = {
+        "quickcluster_btn": (By.XPATH, '/html/body/div/div/div/div/nav/ul/li/button')
+    }

--- a/ui_tests/features/steps/rhub_login.py
+++ b/ui_tests/features/steps/rhub_login.py
@@ -1,29 +1,31 @@
 import time
 
-@given(u'web address "https://rhub-app-resource-hub-dev.apps.ocp4.prod.psi.redhat.com"')
-def step_impl(context):
-    context.browser.get("https://rhub-app-resource-hub-dev.apps.ocp4.prod.psi.redhat.com")
+from helpers.login_page import LoginPage
+from helpers.main_page import MainPage
+from behave import *
 
+@given(u'web address "{url}"')
+def step_impl(context, url):
+    login_page = LoginPage(context)
+    login_page.visit(url)
 
-@given(u'login name "testuser1" and password "testuser1"')
-def step_impl(context):
-    time.sleep(2)
-    context.browser.maximize_window()
-    context.browser.find_element_by_xpath("/html/body/div/div/main/div/div[1]/div[2]/button").click()
-    context.browser.find_element_by_id("username").click()
-    context.browser.find_element_by_id("username").clear()
-    context.browser.find_element_by_id("username").send_keys("testuser1")
-    context.browser.find_element_by_id("password").click()
-    context.browser.find_element_by_id("password").clear()
-    context.browser.find_element_by_id("password").send_keys("testuser1")
+@given(u'login name "{name:w}" and password "{password:w}"')
+def step_impl(context, name, password):
+    login_page = LoginPage(context)
+    login_page.login_btn.click()
+    login_page.input(login_page.username, name)
+    login_page.input(login_page.password, password)
+
 
 @when(u'i confirm pressing the sing in button')
 def step_impl(context):
-    context.browser.find_element_by_id("kc-login").click()
+    login_page = LoginPage(context)
+    login_page.sign_in_btn.click()
 
 
 @then(u'the application should show the welcome message')
 def step_impl(context):
-    time.sleep(1)
-    name=context.browser.find_element_by_xpath('/html/body/div/div/div/div/nav/ul/li/button').text
-    assert (name == "QuickCluster")
+
+    main_page = MainPage(context)
+    
+    assert(main_page.quickcluster_btn.text == "QuickCluster")

--- a/ui_tests/features/steps/rhub_login.py
+++ b/ui_tests/features/steps/rhub_login.py
@@ -1,5 +1,3 @@
-import time
-
 from helpers.login_page import LoginPage
 from helpers.main_page import MainPage
 from behave import *


### PR DESCRIPTION
Creates page classes for the tested pages. The specific pages inherit from the `BasePage` object that provides some of the basic functionality. Specific page classes should define a `locators` dictionary containing the entries for the needed elements of the page in the form of a tuple, e.g. (locator, attribute value). Keys of this dictionary then can be used as attributes of the given class thanks to the `__getattr__` method implemented in the `BasePage` class.

The existing tests for the RHub login page were updated so that they use these newly created classes.

Implicit wait time was added to operations regarding finding elements on a page. This way there is no need to call the `time.sleep()` function before actions that require the page to be loaded. 