### PR TITLE
Adding an infrastructure for creating CLI end-to-end tests.

### DIFF
--- a/tests/features/cli_cowsay.feature
+++ b/tests/features/cli_cowsay.feature
@@ -1,0 +1,8 @@
+@fixture.cli
+Feature: Cowsay
+
+    Scenario: Cowsay
+        Given   User is authenticated
+        When    I execute the "cowsay get" command
+        And     I execute the cowsay API call
+        Then    API and CLI outputs match

--- a/tests/features/cli_ping.feature
+++ b/tests/features/cli_ping.feature
@@ -1,0 +1,8 @@
+@fixture.cli
+Feature: Ping
+
+    Scenario: Ping
+        Given   User is authenticated
+        When    I execute the "ping get" command
+        And     I execute the ping API call
+        Then    API and CLI outputs match

--- a/tests/features/cli_policies.feature
+++ b/tests/features/cli_policies.feature
@@ -1,0 +1,20 @@
+@fixture.cli
+Feature: Policies
+
+    Scenario: Get a list of existing policies
+        Given   User is authenticated
+        When    I execute the "policies get-list" command
+        And     I get a list of policies
+        Then    API and CLI outputs match
+
+    Scenario: Create a new policy
+        Given   User is authenticated
+        When    I execute the "policies create --name test-policy --department test-department" command
+        And     I create a policy with name "test-policy" and department "test-department"
+        Then    API and CLI outputs match
+
+    Scenario: Create a new policy with constraints
+        Given   User is authenticated
+        When    I execute the "policies create --name test-policy --department test-department --constraint-cost 1 --constraint-density 'very dense'" command
+        And     I create a policy with name "test-policy", department "test-department" and constraints {"cost": 1, "density": "very dense"}
+        Then    API and CLI outputs match

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -1,10 +1,20 @@
 import time
 import os
-import requests
+import fixtures
 
+from behave.fixture import use_fixture_by_tag
 from selenium import webdriver
 
 t = time.localtime()
+
+fixture_registry = {
+    "fixture.cli": fixtures.rhub_cli
+}
+
+
+def before_tag(context, tag):
+    if tag.startswith('fixture.'):
+        use_fixture_by_tag(tag, context, fixture_registry)
 
 
 def before_scenario(context, scenario):
@@ -19,6 +29,7 @@ def before_scenario(context, scenario):
         os.system(
             './../tools/cm selenoid start --browsers-json ./../tools/browsers.json')
         os.system('./../tools/cm selenoid-ui start')
+
         time.sleep(5)
 
         capabilities = {

--- a/tests/features/fixtures.py
+++ b/tests/features/fixtures.py
@@ -1,0 +1,33 @@
+import sys
+import subprocess
+
+from steps.cli.cli_model import ResourceHubCLI
+from tempfile import TemporaryDirectory
+from behave import fixture
+from pathlib import Path
+
+
+@fixture
+def rhub_cli(context):
+    try:
+        temp_directory = TemporaryDirectory()
+        temp_directory_path = Path(temp_directory.name)
+
+        # create temporary python virtual environment
+        subprocess.run(
+            [sys.executable, '-m', 'venv', temp_directory.name],
+            check=True,
+        )
+
+        # install RHub CLI on the created virtual environment
+        subprocess.run(
+            f"source {temp_directory_path / 'bin/activate'} ; pip install -q {ResourceHubCLI.PIP_CLONE_URL}",
+            check=True,
+            shell=True,
+        )
+
+        context.cli = ResourceHubCLI(temp_directory_path)
+        yield context.cli
+
+    finally:
+        temp_directory.cleanup()

--- a/tests/features/steps/api/api.py
+++ b/tests/features/steps/api/api.py
@@ -25,7 +25,7 @@ class API(object):
         self.ping = PingEndpoint(self.session)
         self.cowsay = CowsayEndpoint(self.session)
 
-    def update_token(self, token):
+    def update_token(self, token: str):
         """
         Updates headers with the provided token.
         """

--- a/tests/features/steps/api/api.py
+++ b/tests/features/steps/api/api.py
@@ -2,6 +2,10 @@ import requests
 
 from api.auth_endpoint import AuthEndpoint
 from api.tower_endpoint import TowerEndpoint
+from api.policies_endpoint import PoliciesEndpoint
+from api.base_endpoint import APILogger
+from api.ping_endpoint import PingEndpoint
+from api.cowsay_endpoint import CowsayEndpoint
 
 
 class API(object):
@@ -15,8 +19,11 @@ class API(object):
         """
 
         self.session = requests.Session()
-        self.auth = AuthEndpoint(self.session)
+        self.auth = AuthEndpoint(self.session,)
         self.tower = TowerEndpoint(self.session)
+        self.policies = PoliciesEndpoint(self.session)
+        self.ping = PingEndpoint(self.session)
+        self.cowsay = CowsayEndpoint(self.session)
 
     def update_token(self, token):
         """

--- a/tests/features/steps/api/auth_endpoint.py
+++ b/tests/features/steps/api/auth_endpoint.py
@@ -1,10 +1,14 @@
-from api.base_endpoint import BaseEndpoint
+from api.base_endpoint import BaseEndpoint, log_call
 
 
 class AuthEndpoint(BaseEndpoint):
     """
     Represents the auth API endpoint.
     """
+
+    UNVERIFIABLE_ITEMS = {
+        "create_token": {}
+    }
 
     def auth_url(self, suffix: str):
         """
@@ -20,9 +24,10 @@ class AuthEndpoint(BaseEndpoint):
         str
             Created url.
         """
-        
+
         return f"{self.base_url}/auth/{suffix}"
 
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["create_token"])
     def create_token(self, auth: tuple):
         """
         Login and get access token.
@@ -34,12 +39,11 @@ class AuthEndpoint(BaseEndpoint):
 
         Returns 
         -------
-        str
-            Refresh token.
+        Response
+            API response.
         """
 
         url = self.auth_url(suffix='token/create')
         response = self.post(url, auth=auth)
-        token = response.json()['refresh_token']
 
-        return token
+        return response

--- a/tests/features/steps/api/auth_endpoint.py
+++ b/tests/features/steps/api/auth_endpoint.py
@@ -1,3 +1,5 @@
+import requests
+
 from api.base_endpoint import BaseEndpoint, log_call
 
 
@@ -10,40 +12,20 @@ class AuthEndpoint(BaseEndpoint):
         "create_token": {}
     }
 
-    def auth_url(self, suffix: str):
+    def auth_url(self, suffix: str) -> str:
         """
         Create an URL for the auth endpoint.
-
-        Arguments
-        ---------
-        suffix: str
-            String appended at the end of the url.
-
-        Returns
-        -------
-        str
-            Created url.
         """
 
-        return f"{self.base_url}/auth/{suffix}"
+        return f"{self.base_url}/auth{suffix}"
 
     @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["create_token"])
-    def create_token(self, auth: tuple):
+    def create_token(self, auth: tuple) -> requests.Response:
         """
         Login and get access token.
-
-        Arguments
-        ---------
-        auth: tuple
-            Auth tuple for basic HTTP authentication.
-
-        Returns 
-        -------
-        Response
-            API response.
         """
 
-        url = self.auth_url(suffix='token/create')
+        url = self.auth_url(suffix='/token/create')
         response = self.post(url, auth=auth)
 
         return response

--- a/tests/features/steps/api/base_endpoint.py
+++ b/tests/features/steps/api/base_endpoint.py
@@ -63,21 +63,9 @@ class BaseEndpoint(object):
         self.base_url = f"{self.HOSTNAME}:{self.PORT}{self.PATH}"
         self.session = session
 
-    def delete(self, url: str, **kwargs):
+    def delete(self, url: str, **kwargs) -> requests.Response:
         """
         Send a DELETE request.
-
-        Arguments
-        ---------
-        url: str
-            Url to send the request to.
-        **kwargs
-            Optional arguments that request takes.
-
-        Returns
-        -------
-        Response
-            Response object.
         """
 
         r = self.session.delete(url, timeout=self.TIMEOUT,
@@ -86,21 +74,9 @@ class BaseEndpoint(object):
 
         return r
 
-    def get(self, url: str, **kwargs):
+    def get(self, url: str, **kwargs) -> requests.Response:
         """
         Send a GET request.
-
-        Arguments
-        ---------
-        url: str
-            Url to send the request to.
-        **kwargs
-            Optional arguments that request takes.
-
-        Returns
-        -------
-        Response
-            Response object.
         """
 
         r = self.session.get(url, timeout=self.TIMEOUT,
@@ -109,21 +85,9 @@ class BaseEndpoint(object):
 
         return r
 
-    def post(self, url: str, **kwargs):
+    def post(self, url: str, **kwargs) -> requests.Response:
         """
         Send a POST request.
-
-        Arguments
-        ---------
-        url: str
-            Url to send the request to.
-        **kwargs
-            Optional arguments that request takes.
-
-        Returns
-        -------
-        Response
-            Response object.
         """
 
         r = self.session.post(url, timeout=self.TIMEOUT,
@@ -132,21 +96,9 @@ class BaseEndpoint(object):
 
         return r
 
-    def patch(self, url: str, **kwargs):
+    def patch(self, url: str, **kwargs) -> requests.Response:
         """
         Send a PATCH request.
-
-        Arguments
-        ---------
-        url: str
-            Url to send the request to.
-        **kwargs
-            Optional arguments that request takes.
-
-        Returns
-        -------
-        Response
-            Response object.
         """
 
         r = self.session.patch(url, timeout=self.TIMEOUT,

--- a/tests/features/steps/api/base_endpoint.py
+++ b/tests/features/steps/api/base_endpoint.py
@@ -1,12 +1,45 @@
-# HOSTNAME = 'https://rhub-api-resource-hub-qe.apps.ocp-c1.prod.psi.redhat.com'
-HOSTNAME = 'http://localhost'
-# PORT = 443
-PORT = '8081'
+import functools
+import requests
 
-PATH = '/v0'
 
-TIMEOUT = 10
-VERIFY = False
+class APILogger(object):
+    """
+    Logs the API calls.
+    """
+
+    def __init__(self):
+        self.responses = []
+        self.unverifiable_items = []
+
+    def log_response(self, response: requests.Response):
+        self.responses.append(response)
+
+    def log_unverfiable_items(self, item: dict):
+        self.unverifiable_items.append(item)
+
+    @property
+    def last_response(self) -> requests.Response | None:
+        if self.responses:
+            return self.responses[-1]
+
+    @property
+    def last_unverifiable_items(self) -> dict | None:
+        if self.unverifiable_items:
+            return self.unverifiable_items[-1]
+
+
+def log_call(logger: APILogger, unverifiable_items: dict):
+    def decorator_log(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            response = func(*args, **kwargs)
+
+            logger.log_response(response)
+            logger.log_unverfiable_items(unverifiable_items)
+
+            return response
+        return wrapper
+    return decorator_log
 
 
 class BaseEndpoint(object):
@@ -14,8 +47,20 @@ class BaseEndpoint(object):
     Base object providing some basic functions for all the inheriting API endoints.
     """
 
-    def __init__(self, session):
-        self.base_url = f"{HOSTNAME}:{PORT}{PATH}"
+    # HOSTNAME = 'https://rhub-api-resource-hub-qe.apps.ocp-c1.prod.psi.redhat.com'
+    # PORT = 443
+    HOSTNAME = 'http://localhost'
+    PORT = '8081'
+    PATH = '/v0'
+
+    TIMEOUT = 10
+    VERIFY = False
+    AUTH = ('testuser1', 'testuser1')
+
+    LOGGER = APILogger()
+
+    def __init__(self, session: requests.Session):
+        self.base_url = f"{self.HOSTNAME}:{self.PORT}{self.PATH}"
         self.session = session
 
     def delete(self, url: str, **kwargs):
@@ -34,8 +79,9 @@ class BaseEndpoint(object):
         Response
             Response object.
         """
-        
-        r = self.session.delete(url, timeout=TIMEOUT, verify=VERIFY, **kwargs)
+
+        r = self.session.delete(url, timeout=self.TIMEOUT,
+                                verify=self.VERIFY, **kwargs)
         r.raise_for_status()
 
         return r
@@ -57,7 +103,8 @@ class BaseEndpoint(object):
             Response object.
         """
 
-        r = self.session.get(url, timeout=TIMEOUT, verify=VERIFY, **kwargs)
+        r = self.session.get(url, timeout=self.TIMEOUT,
+                             verify=self.VERIFY, **kwargs)
         r.raise_for_status()
 
         return r
@@ -79,7 +126,8 @@ class BaseEndpoint(object):
             Response object.
         """
 
-        r = self.session.post(url, timeout=TIMEOUT, verify=VERIFY, **kwargs)
+        r = self.session.post(url, timeout=self.TIMEOUT,
+                              verify=self.VERIFY, **kwargs)
         r.raise_for_status()
 
         return r
@@ -101,7 +149,8 @@ class BaseEndpoint(object):
             Response object.
         """
 
-        r = self.session.patch(url, timeout=TIMEOUT, verify=VERIFY, **kwargs)
+        r = self.session.patch(url, timeout=self.TIMEOUT,
+                               verify=self.VERIFY, **kwargs)
         r.raise_for_status()
 
         return r

--- a/tests/features/steps/api/cowsay_endpoint.py
+++ b/tests/features/steps/api/cowsay_endpoint.py
@@ -1,0 +1,23 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint, log_call
+
+
+class CowsayEndpoint(BaseEndpoint):
+    """
+    Represents the cowsay API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {
+        "cowsay": {}
+    }
+
+    def cowsay_url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/cowsay{suffix}"
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["cowsay"])
+    def cowsay(self) -> requests.Response:
+        url = self.cowsay_url()
+        response = self.get(url)
+
+        return response

--- a/tests/features/steps/api/ping_endpoint.py
+++ b/tests/features/steps/api/ping_endpoint.py
@@ -1,0 +1,23 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint, log_call
+
+
+class PingEndpoint(BaseEndpoint):
+    """
+    Represents the ping API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {
+        "ping": {}
+    }
+
+    def ping_url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/ping{suffix}"
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["ping"])
+    def ping(self) -> requests.Response:
+        url = self.ping_url()
+        response = self.get(url)
+
+        return response

--- a/tests/features/steps/api/policies_endpoint.py
+++ b/tests/features/steps/api/policies_endpoint.py
@@ -19,7 +19,7 @@ class PoliciesEndpoint(BaseEndpoint):
         return f"{self.base_url}/policies{suffix}"
 
     @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["create"])
-    def create(self, name, department, constraint=None) -> requests.Response:
+    def create(self, name: str, department: str, constraint: dict = None) -> requests.Response:
         """
         Create a new policy.
         """
@@ -40,7 +40,7 @@ class PoliciesEndpoint(BaseEndpoint):
         return response
 
     @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["get_list"])
-    def get_list(self):
+    def get_list(self) -> requests.Response:
         """
         Get a list of all policies.
         """

--- a/tests/features/steps/api/policies_endpoint.py
+++ b/tests/features/steps/api/policies_endpoint.py
@@ -1,0 +1,51 @@
+import json
+import requests
+
+from api.base_endpoint import BaseEndpoint, log_call
+
+
+class PoliciesEndpoint(BaseEndpoint):
+    """
+    Represents the policies API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {
+        # TODO: constraint['cost'] is just an example of nested fields and can be removed
+        "create": {'constraint': {'cost': False}, 'id': True},
+        "get_list": {}
+    }
+
+    def policies_url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/policies{suffix}"
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["create"])
+    def create(self, name, department, constraint=None) -> requests.Response:
+        """
+        Create a new policy.
+        """
+
+        url = self.policies_url()
+
+        params = {
+            'name': name,
+            'department': department,
+        }
+
+        if constraint:
+            params["constraint"] = json.loads(constraint)
+
+        response = self.post(url, json=params)
+
+        print(response)
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["get_list"])
+    def get_list(self):
+        """
+        Get a list of all policies.
+        """
+
+        url = self.policies_url()
+        response = self.get(url)
+
+        return response

--- a/tests/features/steps/api/tower_endpoint.py
+++ b/tests/features/steps/api/tower_endpoint.py
@@ -1,12 +1,16 @@
 import json
 
-from api.base_endpoint import BaseEndpoint
+from api.base_endpoint import BaseEndpoint, log_call
 
 
 class TowerEndpoint(BaseEndpoint):
     """
     Represents the tower API endpoint.
     """
+
+    UNVERIFIABLE_ITEMS = {
+        "list_jobs": {}
+    }
 
     def tower_url(self, suffix: str):
         """
@@ -25,6 +29,7 @@ class TowerEndpoint(BaseEndpoint):
 
         return f"{self.base_url}/tower/{suffix}"
 
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["list_jobs"])
     def list_jobs(self, filter: dict = None, page: int = None, limit: int = None):
         """
         List tower jobs.
@@ -58,4 +63,4 @@ class TowerEndpoint(BaseEndpoint):
         url = self.tower_url(suffix='job')
         response = self.get(url, params=params)
 
-        return response.json()
+        return response

--- a/tests/features/steps/api/tower_endpoint.py
+++ b/tests/features/steps/api/tower_endpoint.py
@@ -1,4 +1,5 @@
 import json
+import requests
 
 from api.base_endpoint import BaseEndpoint, log_call
 
@@ -12,41 +13,17 @@ class TowerEndpoint(BaseEndpoint):
         "list_jobs": {}
     }
 
-    def tower_url(self, suffix: str):
+    def tower_url(self, suffix: str) -> str:
         """
         Create an URL for the tower endpoint.
-
-        Arguments
-        ---------
-        suffix: str
-            String appended at the end of the url.
-
-        Returns
-        -------
-        str
-            Created url.
         """
 
-        return f"{self.base_url}/tower/{suffix}"
+        return f"{self.base_url}/tower{suffix}"
 
     @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS["list_jobs"])
-    def list_jobs(self, filter: dict = None, page: int = None, limit: int = None):
+    def list_jobs(self, filter: dict = None, page: str = None, limit: str = None) -> requests.Response:
         """
         List tower jobs.
-
-        Arguments
-        ---------
-        filter: dict
-            Filter jobs by attributes.
-        page: int
-            Page number.
-        limit: int
-            Limit.
-
-        Returns
-        -------
-        dict
-            Tower jobs.
         """
 
         params = {}
@@ -60,7 +37,7 @@ class TowerEndpoint(BaseEndpoint):
         if limit:
             params["limit"] = limit
 
-        url = self.tower_url(suffix='job')
+        url = self.tower_url(suffix='/job')
         response = self.get(url, params=params)
 
         return response

--- a/tests/features/steps/api_health.py
+++ b/tests/features/steps/api_health.py
@@ -1,0 +1,11 @@
+from behave import given, when, then
+
+
+@when(u'I execute the ping API call')
+def step_impl(context):
+    context.api.ping.ping()
+
+
+@when(u'I execute the cowsay API call')
+def step_impl(context):
+    context.api.cowsay.cowsay()

--- a/tests/features/steps/api_login.py
+++ b/tests/features/steps/api_login.py
@@ -3,18 +3,27 @@ from api.api import API
 
 auth = AUTH_USER = ('testuser1', 'testuser1')
 
+
 @given(u'I request the token')
 def step_impl(context):
     context.api = API()
 
-    token_f = context.api.auth.create_token(auth)
-    context.token = token_f
+    response = context.api.auth.create_token(auth)
+    context.token = response.json()['refresh_token']
 
-    assert(token_f != '')
+    assert(context.token != '')
 
-    context.api.update_token(token_f)
+    context.api.update_token(context.token)
 
-    
+
+@given(u'User is authenticated')
+def step_impl(context):
+    context.execute_steps(u'''
+        Given I request the token
+        When I execute the authentication
+    ''')
+
+
 @when(u'I execute the authentication')
 def step_impl(context):
     # use token with random endpoint

--- a/tests/features/steps/api_policies.py
+++ b/tests/features/steps/api_policies.py
@@ -1,0 +1,16 @@
+from behave import given, when, then
+
+
+@when(u'I create a policy with name "{name}", department "{department}" and constraints {constraint}')
+def step_impl(context, name, department, constraint):
+    context.api.policies.create(name, department, constraint)
+
+
+@when(u'I create a policy with name "{name}" and department "{department}"')
+def step_impl(context, name, department):
+    context.api.policies.create(name, department, None)
+
+
+@when(u'I get a list of policies')
+def step_impl(context):
+    context.api.policies.get_list()

--- a/tests/features/steps/cli/cli_model.py
+++ b/tests/features/steps/cli/cli_model.py
@@ -1,0 +1,101 @@
+import sys
+import subprocess
+import requests
+import json
+
+from pathlib import Path
+
+
+class ResourceHubCLI:
+    API_BASE_URL = 'http://localhost:8081/v0'
+    API_USER = 'testuser1'
+    API_PASS = 'testuser1'
+
+    # TODO: API needs to be on the same version as the CLI code being tested
+    # TODO: switch back to official repo
+    # PIP_CLONE_URL = 'git+ssh://git@github.com/resource-hub-dev/rhub-cli.git'
+    PIP_CLONE_URL = 'git+ssh://git@github.com/guioliveirabh/rhub-cli@test_generation'
+    # PIP_CLONE_URL = 'git+ssh://git@github.com/simonkosina/rhub-cli@format-fix'
+
+    def __init__(self, virtual_environment_path: Path):
+        self.entrypoint = str(virtual_environment_path / 'bin/rhub-cli')
+        self.base_command = [
+            self.entrypoint,
+            '--data-format', 'json',
+            '--base-url', self.API_BASE_URL,
+            '--user', self.API_USER,
+            '--password', self.API_PASS,
+        ]
+        self.last_output = ''
+
+    def run(self, cli_args: list[str]):
+        """
+        Execute a CLI command.
+        """
+        self.last_output = None
+        self.last_cli_args = cli_args
+        command = self.base_command + cli_args
+
+        try:
+            process_status = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as error:
+            error_msg = error.stderr.decode('utf-8')
+            print(error_msg, file=sys.stderr)
+
+            raise(error)
+
+        self.last_output = self._format_cli_output(process_status.stdout)
+
+    def _format_cli_output(self, output: str):
+        """
+        Format the CLI output for comparison.
+        """
+
+        try:
+            return json.loads(output)
+        except json.JSONDecodeError:
+            return output.rstrip()
+
+    def _format_api_output(self, response: requests.Response):
+        """
+        Format the API response for comparison.
+        """
+
+        try:
+            return response.json()
+        except json.JSONDecodeError:
+            return response.content.rstrip()
+
+    def _prepare_dict(self, dictionary: dict, keys_to_remove: dict) -> dict:
+        """
+        Removes keys from the original dictionary which are not compared during verification.
+        """
+
+        for k, v in keys_to_remove.items():
+            if type(v) is dict:
+                # recursively remove nested fields
+                self._prepare_dict(dictionary[k], v)
+            elif v is True:
+                del dictionary[k]
+
+    def verify(self, api_response: requests.Response, unverifiable_items: dict) -> bool:
+        """
+        Compare the last CLI output with the API response.
+        """
+        api_output = self._format_api_output(api_response)
+        cli_output = self.last_output
+
+        print(f"> CLI output:\n{cli_output}\n\n> API response:\n{api_output}")
+
+        if type(api_output) is not type(cli_output):
+            return False
+
+        if type(api_output) is dict:
+            self._prepare_dict(api_output, unverifiable_items)
+            self._prepare_dict(cli_output, unverifiable_items)
+
+        return api_output == cli_output

--- a/tests/features/steps/cli/cli_model.py
+++ b/tests/features/steps/cli/cli_model.py
@@ -12,10 +12,7 @@ class ResourceHubCLI:
     API_PASS = 'testuser1'
 
     # TODO: API needs to be on the same version as the CLI code being tested
-    # TODO: switch back to official repo
-    # PIP_CLONE_URL = 'git+ssh://git@github.com/resource-hub-dev/rhub-cli.git'
-    PIP_CLONE_URL = 'git+ssh://git@github.com/guioliveirabh/rhub-cli@test_generation'
-    # PIP_CLONE_URL = 'git+ssh://git@github.com/simonkosina/rhub-cli@format-fix'
+    PIP_CLONE_URL = 'git+ssh://git@github.com/resource-hub-dev/rhub-cli.git'
 
     def __init__(self, virtual_environment_path: Path):
         self.entrypoint = str(virtual_environment_path / 'bin/rhub-cli')

--- a/tests/features/steps/cli_steps.py
+++ b/tests/features/steps/cli_steps.py
@@ -1,0 +1,16 @@
+import shlex
+
+from behave import when, then
+from api.base_endpoint import BaseEndpoint
+
+
+@when('I execute the "{cmd}" command')
+def step_impl(context, cmd):
+    context.cli.run(shlex.split(cmd))
+
+
+@then('API and CLI outputs match')
+def step_impl(context):
+    logger = BaseEndpoint.LOGGER
+
+    assert(context.cli.verify(logger.last_response, logger.last_unverifiable_items))


### PR DESCRIPTION
This PR adds a basic infrastructure which will help us in creating end-to-end CLI tests. It makes use of the `ResourceHubCLI` class and a virtual python environment created during the fixture setup process. Here the CLI utility is installed and commands are later executed.

So far the CLI commands are verified by comparing them to equivalent API calls. This introduced a need to implement a simple `APILogger` class and the `@log_call` decorator which store the results of the API calls and also remember the items that should not be compared during the verification process, e.g. database IDs, timestamps, etc.