### PR TITLE
Add infrastructure for /openstack API endpoint

### DIFF
--- a/tests/features/steps/api/api.py
+++ b/tests/features/steps/api/api.py
@@ -7,6 +7,7 @@ from api.policies_endpoint import PoliciesEndpoint
 from api.ping_endpoint import PingEndpoint
 from api.cowsay_endpoint import CowsayEndpoint
 from api.lab_endpoint import LabEndpoint
+from api.openstack_endpoint import OpenstackEndpoint
 
 
 class API(object):
@@ -22,6 +23,7 @@ class API(object):
         self.session = requests.Session()
         self.auth = AuthEndpoint(self.session)
         self.lab = LabEndpoint(self.session)
+        self.openstack = OpenstackEndpoint(self.session)
         self.tower = TowerEndpoint(self.session)
         self.policies = PoliciesEndpoint(self.session)
         self.ping = PingEndpoint(self.session)

--- a/tests/features/steps/api/openstack_cloud_endpoint.py
+++ b/tests/features/steps/api/openstack_cloud_endpoint.py
@@ -1,0 +1,79 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint, log_call
+
+
+class OpenstackCloudEndpoint(BaseEndpoint):
+    """
+    Represents openstack/cloud API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {
+        'get_list': {},
+        'create': {'id': True},
+        'delete': {},
+        'get': {},
+        'update': {}
+    }
+
+    def url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/openstack/cloud{suffix}"
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get_list'])
+    def get_list(self) -> requests.Response:
+        response = super().get(self.url())
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['create'])
+    def create(
+        self,
+        credentials: str | dict,
+        domain_id: str,
+        domain_name: str,
+        name: str,
+        networks: list[str],
+        owner_group_id: str,
+        url: str,
+        description: str = None,
+    ) -> requests.Response:
+        args = self.get_function_arguments(locals(), skip_args=['self'])
+        body = self.create_body(args)
+
+        response = self.post(self.url(), json=body)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['delete'])
+    def delete(self, id: int) -> requests.Response:
+        url = self.url(suffix=f"/{id}")
+        response = super().delete(url)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get'])
+    def get(self, id: int) -> requests.Response:
+        url = self.url(suffix=f"/{id}")
+        response = super().get(url)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['update'])
+    def update(
+        self,
+        id: int,
+        credentials: str | dict = None,
+        domain_id: str = None,
+        domain_name: str = None,
+        name: str = None,
+        networks: list[str] = None,
+        owner_group_id: str = None,
+        url: str = None,
+        description: str = None,
+    ) -> requests.Response:
+        args = self.get_function_arguments(locals(), skip_args=['id', 'self'])
+        body = self.create_body(args)
+
+        response = self.patch(self.url(suffix=f"/{id}"), json=body)
+
+        return response

--- a/tests/features/steps/api/openstack_endpoint.py
+++ b/tests/features/steps/api/openstack_endpoint.py
@@ -1,0 +1,20 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint
+from api.openstack_cloud_endpoint import OpenstackCloudEndpoint
+from api.openstack_project_endpoint import OpenstackProjectEndpoint
+
+
+class OpenstackEndpoint(BaseEndpoint):
+    """
+    Represents the OpenStack API endpoint.
+    """
+
+    def __init__(self, session: requests.Session):
+        super().__init__(session)
+
+        self.cloud = OpenstackCloudEndpoint(self.session)
+        self.project = OpenstackProjectEndpoint(self.session)
+
+    def url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/openstack{suffix}"

--- a/tests/features/steps/api/openstack_project_endpoint.py
+++ b/tests/features/steps/api/openstack_project_endpoint.py
@@ -1,0 +1,83 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint, log_call
+
+
+class OpenstackProjectEndpoint(BaseEndpoint):
+    """
+    Represents the openstack/project API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {
+        'get_list': {},
+        'create': {'id': True},
+        'delete': {},
+        'get': {},
+        'update': {},
+        'get_limits': {}
+    }
+
+    def url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/openstack/project{suffix}"
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get_list'])
+    def get_list(self) -> requests.Response:
+        response = super().get(self.url())
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['create'])
+    def create(
+        self,
+        cloud_id: int,
+        name: str,
+        owner_id: str,
+        description: str = None,
+        group_id: str = None,
+    ) -> requests.Response:
+        args = self.get_function_arguments(locals(), skip_args=['self'])
+        body = self.create_body(args)
+
+        response = self.post(self.url(), json=body)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['delete'])
+    def delete(self, id: int) -> requests.Response:
+        url = self.url(suffix=f"/{id}")
+        response = super().delete(url)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get'])
+    def get(self, id: int) -> requests.Response:
+        url = self.url(suffix=f"/{id}")
+        response = super().get(url)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['update'])
+    def update(
+        self,
+        project_id: int,
+        cloud_id: int = None,
+        name: str = None,
+        owner_id: str = None,
+        description: str = None,
+        group_id: str = None
+    ) -> requests.Response:
+        args = self.get_function_arguments(
+            locals(), skip_args=['self', 'project_id'])
+        body = self.create_body(args)
+        url = self.url(suffix=f"/{project_id}")
+
+        response = self.patch(url, json=body)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get_limits'])
+    def get_limits(self, id: int) -> requests.Response:
+        url = self.url(suffix=f"/{id}/limits")
+        response = super().get(url)
+
+        return response


### PR DESCRIPTION
Creating infrastructure for testing the /openstack API endpoint. Relates to [EXDRHUB-1096](https://issues.redhat.com/browse/EXDRHUB-1096).