### PR TITLE
Add infrastructure for /monitor API endpoint

### DIFF
--- a/tests/features/steps/api/api.py
+++ b/tests/features/steps/api/api.py
@@ -9,6 +9,7 @@ from api.policies_endpoint import PoliciesEndpoint
 from api.ping_endpoint import PingEndpoint
 from api.cowsay_endpoint import CowsayEndpoint
 from api.openstack_endpoint import OpenstackEndpoint
+from api.monitor_endpoint import MonitorEndpoint
 
 
 class API(object):
@@ -26,6 +27,7 @@ class API(object):
         self.bare_metal = BaremetalEndpoint(self.session)
         self.lab = LabEndpoint(self.session)
         self.openstack = OpenstackEndpoint(self.session)
+        self.monitor = MonitorEndpoint(self.session)
         self.tower = TowerEndpoint(self.session)
         self.policies = PoliciesEndpoint(self.session)
         self.ping = PingEndpoint(self.session)

--- a/tests/features/steps/api/monitor_bm_endpoint.py
+++ b/tests/features/steps/api/monitor_bm_endpoint.py
@@ -1,0 +1,39 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint, log_call
+
+
+class MonitorBMEndpoint(BaseEndpoint):
+    """
+    Represents the /monitor/bm API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {
+        'get_hosts': {},
+        'get_metrics': {},
+        'get_power_states_metrics': {},
+    }
+
+    def url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/monitor/bm{suffix}"
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get_hosts'])
+    def get_hosts(self, host_type: str) -> requests.Response:
+        url = self.url(suffix=f"/hosts/{host_type}")
+        response = super().get(url)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get_metrics'])
+    def get_metrics(self) -> requests.Response:
+        url = self.url(suffix=f"/metrics")
+        response = super().get(url)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get_power_states_metrics'])
+    def get_power_states_metrics(self) -> requests.Response:
+        url = self.url(suffix=f"/power_states_metrics")
+        response = super().get(url)
+
+        return response

--- a/tests/features/steps/api/monitor_endpoint.py
+++ b/tests/features/steps/api/monitor_endpoint.py
@@ -1,0 +1,24 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint
+from api.monitor_bm_endpoint import MonitorBMEndpoint
+from api.monitor_lab_endpoints import MonitorLabEndpoint
+from api.monitor_vm_endpoint import MonitorVMEndpoint
+
+
+class MonitorEndpoint(BaseEndpoint):
+    """
+    Represents the /monitor API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {}
+
+    def __init__(self, session: requests.Session):
+        super().__init__(session)
+
+        self.bm = MonitorBMEndpoint(self.session)
+        self.lab = MonitorLabEndpoint(self.session)
+        self.vm = MonitorVMEndpoint(self.session)
+
+    def url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/monitor{suffix}"

--- a/tests/features/steps/api/monitor_lab_endpoints.py
+++ b/tests/features/steps/api/monitor_lab_endpoints.py
@@ -1,0 +1,23 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint, log_call
+
+
+class MonitorLabEndpoint(BaseEndpoint):
+    """
+    Represents the /monitor/bm API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {
+        'get_metrics': {}
+    }
+
+    def url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/monitor/lab{suffix}"
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get_metrics'])
+    def get_metrics(self) -> requests.Response:
+        url = self.url(suffix=f"/metrics")
+        response = super().get(url)
+
+        return response

--- a/tests/features/steps/api/monitor_vm_endpoint.py
+++ b/tests/features/steps/api/monitor_vm_endpoint.py
@@ -1,0 +1,23 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint, log_call
+
+
+class MonitorVMEndpoint(BaseEndpoint):
+    """
+    Represents the /monitor/vm API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {
+        'get_metrics': {}
+    }
+
+    def url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/monitor/vm{suffix}"
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get_metrics'])
+    def get_metrics(self) -> requests.Response:
+        url = self.url(suffix=f"/metrics")
+        response = super().get(url)
+
+        return response


### PR DESCRIPTION
Adding infrastructure for testing the /monitor API endpoint. Relates to [EXDRHUB-1097](https://issues.redhat.com/browse/EXDRHUB-1097).