### PR TITLE
Add infrastructure for /dns API endpoint

### DIFF
--- a/tests/features/steps/api/api.py
+++ b/tests/features/steps/api/api.py
@@ -9,6 +9,7 @@ from api.policies_endpoint import PoliciesEndpoint
 from api.ping_endpoint import PingEndpoint
 from api.cowsay_endpoint import CowsayEndpoint
 from api.openstack_endpoint import OpenstackEndpoint
+from api.dns_endpoint import DNSEndpoint
 
 
 class API(object):
@@ -31,6 +32,7 @@ class API(object):
         self.ping = PingEndpoint(self.session)
         self.cowsay = CowsayEndpoint(self.session)
         self.me = MeEndpoint(self.session)
+        self.dns = DNSEndpoint(self.session)
 
     def update_token(self, access_token: str):
         """

--- a/tests/features/steps/api/dns_endpoint.py
+++ b/tests/features/steps/api/dns_endpoint.py
@@ -1,0 +1,21 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint
+from api.dns_server_endpoint import DNSServerEndpoint
+
+
+class DNSEndpoint(BaseEndpoint):
+    """
+    Represents the /dns API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {}
+
+    def __init__(self, session: requests.Session):
+        super().__init__(session)
+
+        self.server = DNSServerEndpoint(self.session)
+
+    def url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/dns{suffix}"
+

--- a/tests/features/steps/api/dns_server_endpoint.py
+++ b/tests/features/steps/api/dns_server_endpoint.py
@@ -1,0 +1,82 @@
+import requests
+
+from api.base_endpoint import BaseEndpoint, log_call
+
+
+class DNSServerEndpoint(BaseEndpoint):
+    """
+    Represents the /dns/server API endpoint.
+    """
+
+    UNVERIFIABLE_ITEMS = {
+        'get_list': {},
+        'create': {},
+        'delete': {},
+        'get': {},
+        'update': {}
+    }
+
+    def url(self, suffix: str = '') -> str:
+        return f"{self.base_url}/dns/server{suffix}"
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get_list'])
+    def get_list(
+        self,
+        filter: dict = None,
+        sort: str = None,
+        page: int = None,
+        limit: int = None
+    ) -> requests.Response:
+        args = self.get_function_arguments(
+            locals(), skip_args=['self', '__class__'])
+        body = self.create_body(args)
+        response = super().get(self.url(), json=body)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['create'])
+    def create(
+        self,
+        credentials: str | dict,
+        hostname: str,
+        description: str = None,
+        name: str = None,
+        owner_group_id: str = None,
+        zone: str = None,
+    ) -> requests.Response:
+        args = self.get_function_arguments(locals(), skip_args=['self'])
+        body = self.create_body(args)
+        response = self.post(self.url(), json=body)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['delete'])
+    def delete(self, id: int) -> requests.Response:
+        url = self.url(suffix=f"/{id}")
+        response = super().delete(url)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['get'])
+    def get(self, id: int) -> requests.Response:
+        url = self.url(suffix=f"/{id}")
+        response = super().get(url)
+
+        return response
+
+    @log_call(BaseEndpoint.LOGGER, UNVERIFIABLE_ITEMS['update'])
+    def update(
+        self,
+        id: int,
+        credentials: str | dict = None,
+        hostname: str = None,
+        description: str = None,
+        name: str = None,
+        owner_group_id: str = None,
+        zone: str = None,
+    ) -> requests.Response:
+        args = self.get_function_arguments(locals(), skip_args=['self', 'id'])
+        body = self.create_body(args)
+        response = self.patch(self.url(suffix=f"/{id}"), json=body)
+
+        return response


### PR DESCRIPTION
Adding infrastructure for testing the /monitor API endpoint. Relates to [EXDRHUB-1098](https://issues.redhat.com/browse/EXDRHUB-1098).