### PR TITLE
Add API tests for /policies endpoint

### DIFF
--- a/tests/features/api_policies_delete.feature
+++ b/tests/features/api_policies_delete.feature
@@ -1,0 +1,26 @@
+@api @policies @delete
+@fixture.api
+Feature: API - /policies DELETE requests
+
+    Scenario: Delete an existing policy
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        And I save the received "policy" id
+        When I send a "delete" request to "policies" endpoint using the saved "policy" id
+        Then I receive a successful response
+
+    Scenario: Delete an existing policy with an invalid token
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        And I save the received "policy" id
+        Given I am authenticated with an invalid token
+        When I send a "delete" request to "policies" endpoint using the saved "policy" id
+        Then I receive an invalid token response
+
+    Scenario: Delete an existing policy with a refreshed token
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        And I save the received "policy" id
+        Given I am authenticated with a refreshed token
+        When I send a "delete" request to "policies" endpoint using the saved "policy" id
+        Then I receive a successful response

--- a/tests/features/api_policies_get.feature
+++ b/tests/features/api_policies_get.feature
@@ -1,0 +1,41 @@
+@api @policies @get
+@fixture.api
+Feature: API - /policies GET requests
+
+    Scenario: Retreive a list of policies
+        Given I am authenticated
+        When I send a "get_list" request to "policies" endpoint
+        Then I receive a list of items with the following structure "policies.get_list"
+
+    Scenario: Retreive a list of users with an invalid token
+        Given I am authenticated with an invalid token
+        When I send a "get_list" request to "policies" endpoint
+        Then I receive an invalid token response
+
+    Scenario: Retreive a list of users with a refreshed token
+        Given I am authenticated with a refreshed token
+        When I send a "get_list" request to "policies" endpoint
+        Then I receive a list of items with the following structure "policies.get_list"
+
+    Scenario: Retreive policy details
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        When I save the received "policy" id
+        When I send a "get" request to "policies" endpoint using the saved "policy" id
+        Then I receive the following response "policies.get"
+
+    Scenario: Retreive policy details with an invalid token
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        When I save the received "policy" id
+        Given I am authenticated with an invalid token
+        When I send a "get" request to "policies" endpoint using the saved "policy" id
+        Then I receive an invalid token response
+
+    Scenario: Retreive policy details with a refreshed token
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        When I save the received "policy" id
+        Given I am authenticated with a refreshed token
+        When I send a "get" request to "policies" endpoint using the saved "policy" id
+        Then I receive the following response "policies.get"

--- a/tests/features/api_policies_patch.feature
+++ b/tests/features/api_policies_patch.feature
@@ -1,0 +1,26 @@
+@api @policies @patch
+@fixture.api
+Feature: API - /policies PATCH requests
+
+    Scenario: Update policy information
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        When I save the received "policy" id
+        When I send a "update" request to "policies" endpoint with body "policies.update" using the saved "policy" id
+        Then I receive the following response "policies.update"
+
+    Scenario: Update policy information with an invalid token
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        When I save the received "policy" id
+        Given I am authenticated with an invalid token
+        When I send a "update" request to "policies" endpoint with body "policies.update" using the saved "policy" id
+        Then I receive an invalid token response
+
+    Scenario: Update policy information with a refreshed token
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        When I save the received "policy" id
+        Given I am authenticated with a refreshed token
+        When I send a "update" request to "policies" endpoint with body "policies.update" using the saved "policy" id
+        Then I receive the following response "policies.update"

--- a/tests/features/api_policies_post.feature
+++ b/tests/features/api_policies_post.feature
@@ -1,0 +1,18 @@
+@api @policies @post
+@fixture.api
+Feature: API - /policies POST requests
+
+    Scenario: Create a new policy
+        Given I am authenticated
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        Then I receive the following response "policies.create"
+
+    Scenario: Create a new policy with an invalid token
+        Given I am authenticated with an invalid token
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        Then I receive an invalid token response
+
+    Scenario: Create a new policy with a refreshed token
+        Given I am authenticated with a refreshed token
+        When I send a "create" request to "policies" endpoint with body "policies.create"
+        Then I receive the following response "policies.create"

--- a/tests/features/steps/api_helpers.py
+++ b/tests/features/steps/api_helpers.py
@@ -226,6 +226,11 @@ def step_impl(context, data_key: str):
         response.raise_for_status()
 
         data = response.json()
+
+        # some responses return the list directly, other contain it in the 'data' item
+        if type(data) is dict:
+            data = data['data']
+
         expected = get_nested(context.api.response_data, data_key.split('.'))
 
         expected_filtered = filter_dict(

--- a/tests/tools/api_policies_requests.json
+++ b/tests/tools/api_policies_requests.json
@@ -1,0 +1,18 @@
+{
+  "policies": {
+    "create": {
+      "department": "Test Department",
+      "name": "Test User",
+      "constraint": {
+        "density": "Very Dense"
+      }
+    },
+    "update": {
+      "constraint": {
+        "tag": ["tag"],
+        "density": "Not So Dense"
+      },
+      "department": "New Department"
+    }
+  }
+}

--- a/tests/tools/api_policies_responses.json
+++ b/tests/tools/api_policies_responses.json
@@ -1,0 +1,51 @@
+{
+  "policies": {
+    "get_list": {
+      "id": 1,
+      "name": "string",
+      "department": "string"
+    },
+    "create": {
+      "constraint": {
+        "cost": null,
+        "density": "Very Dense",
+        "limit": null,
+        "location_id": null,
+        "sched_avail": null,
+        "serv_avail": null,
+        "tag": null
+      },
+      "department": "Test Department",
+      "id": 7,
+      "name": "Test User"
+    },
+    "get": {
+      "constraint": {
+        "cost": null,
+        "density": "Very Dense",
+        "limit": null,
+        "location_id": null,
+        "sched_avail": null,
+        "serv_avail": null,
+        "tag": null
+      },
+      "department": "Test Department",
+      "id": 7,
+      "name": "Test User"
+    },
+    "update": {
+      "constraint": {
+        "cost": null,
+        "density": "Not So Dense",
+        "limit": null,
+        "location_id": null,
+        "sched_avail": null,
+        "serv_avail": null,
+        "tag": ["tag"]
+      },
+      "department": "New Department",
+      "id": 7,
+      "name": "Test User"
+    }
+  }
+}


### PR DESCRIPTION
Adding end-to-end tests and data for the `/policies` API endpoint. Updated some of the methods in `PoliciesEndpoint` class to support environment cleanups.

Relates to [EXDRHUB-1230](https://issues.redhat.com/browse/EXDRHUB-1230).